### PR TITLE
升级react-styleguidist,解决老版本exmaple时,不支持import语法

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ydoc-plugin-react-styleguide",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -19,7 +19,7 @@
   "license": "ISC",
   "devDependencies": {},
   "dependencies": {
-    "react-styleguidist": "^7.3.8",
+    "react-styleguidist": "^10.6.2",
     "shelljs": "^0.8.2"
   }
 }


### PR DESCRIPTION
react-styleguidist版本过久，不支持
```js
import {a} from 'a';
```
写法